### PR TITLE
Port changes from phlex-v0.2 to main branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(TBB REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(phlex REQUIRED)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+add_compile_options(-Wall -Wpedantic -Werror)
 
 # Proxies for framework-agnostic experiment libraries
 # N.B. The specified library type should be SHARED.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repository can now be easily built by activating [the environment you create
 
 ```console
 spack env activate my-phlex-environment
-spack load cmake gcc@14  # adjust if you used a different compiler for phlex
+spack load cmake gcc@15  # adjust if you used a different compiler for phlex
 cmake ../phlex-examples
 make -j 12  # choose a suitable number of jobs for your machine
 ```

--- a/subtract.py
+++ b/subtract.py
@@ -38,4 +38,4 @@ def PHLEX_REGISTER_ALGORITHMS(m, config):
     """
     m.transform(subtract,
                 input_family = config["input"],
-                output_products = config["output"])
+                output_product_suffixes = config["output"])

--- a/test-py-workflow.jsonnet
+++ b/test-py-workflow.jsonnet
@@ -11,7 +11,10 @@
   modules: {
     subtract: {
       py: 'subtract',
-      input: ['i', 'j'],
+      input: [
+        { creator: 'input', suffix: 'i', layer: 'job' },
+        { creator: 'input', suffix: 'j', layer: 'job' },
+      ],
       output: ['difference'],
     },
     // Python data products cannot yet be written to output files


### PR DESCRIPTION
Port changes from phlex-v0.2 branch to main branch to make them consistent and they are needed on main as well.

1. Update use instructions to use GCC15
2. Remove unnecessary extra warnings
3. Update Python workflow to accommodate Phlex v0.2.0