### PR TITLE
Add minimal unfold example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,13 @@ target_link_libraries(add_and_verify PRIVATE phlex::module my_add my_geometry)
 # Enable asserts for add_and_verify
 # N.B. This should not be done for production code, but it is useful for testing and development.
 target_compile_options(add_and_verify PRIVATE -UNDEBUG)
+
+# Unfold example: vector<int> on parent layer -> int on child layer
+add_library(vector_source MODULE vector_source.cpp)
+target_link_libraries(vector_source PRIVATE phlex::module)
+
+add_library(split_square_verify MODULE split_square_verify.cpp)
+target_link_libraries(split_square_verify PRIVATE phlex::module)
+
+# Enable asserts for split_square_verify
+target_compile_options(split_square_verify PRIVATE -UNDEBUG)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ Processed layers:
 [2025-12-22 13:17:51.760] [info] Max. RSS: 268.848 MB
 ```
 
+### Job with an unfold
+
+To run a job that demonstrates the `unfold` higher-order function — splitting a
+parent-layer product into a child layer of data cells — use:
+
+```console
+phlex -c ../phlex-examples/test-cpp-unfold-workflow.jsonnet
+```
+
+The source provides a `std::vector<int>` per `spill`, the unfold emits one `int`
+per element on a child `number` layer, a transform squares each value, and an
+observer asserts the result. The output should look like:
+
+```console
+[info]
+Processed layers:
+
+  job
+   │
+   └ spill: 5
+      │
+      └ number: 15
+
+[info] CPU time: ...
+```
+
+`number: 15` is 3 elements × 5 spills.
+
 ### Job with Python algorithms
 
 To run a job that uses a Python algorithm, the `PYTHONPATH` environment variable must be adjusted to include the directory with the Python module:

--- a/split_square_verify.cpp
+++ b/split_square_verify.cpp
@@ -1,0 +1,55 @@
+#include "phlex/module.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+// Splitter for an unfold. The framework constructs one per parent cell from
+// the input product (the constructor signature is inspected to deduce the
+// expected number and types of input products), then iterates by threading
+// an opaque state value:
+//
+//   initial_value()  -> first state
+//   predicate(state) -> true while more children remain
+//   unfold(state)    -> { next state, emitted child product }
+class VectorSplitter {
+public:
+  explicit VectorSplitter(std::vector<int> values) : values_{std::move(values)} {}
+
+  std::size_t initial_value() const { return 0; }
+  bool predicate(std::size_t i) const { return i < values_.size(); }
+  std::pair<std::size_t, int> unfold(std::size_t i) const { return {i + 1, values_[i]}; }
+
+private:
+  std::vector<int> values_;
+};
+
+PHLEX_REGISTER_ALGORITHMS(m, config)
+{
+  using namespace phlex;
+
+  auto const parent_layer = config.get<std::string>("parent_layer");
+  auto const child_layer = config.get<std::string>("child_layer");
+
+  m.unfold<VectorSplitter>(
+     "split",
+     &VectorSplitter::predicate,
+     &VectorSplitter::unfold,
+     child_layer,
+     concurrency::unlimited)
+    .input_family(product_selector{
+      .creator = "input", .layer = parent_layer, .suffix = "numbers"})
+    .output_product_suffixes("number");
+
+  m.transform(
+     "square", [](int n) { return n * n; }, concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "split", .layer = child_layer, .suffix = "number"})
+    .output_product_suffixes("squared");
+
+  m.observe(
+     "verify", [](int sq) { assert(sq >= 0); }, concurrency::unlimited)
+    .input_family(
+      product_selector{.creator = "square", .layer = child_layer, .suffix = "squared"});
+}

--- a/test-cpp-unfold-workflow.jsonnet
+++ b/test-cpp-unfold-workflow.jsonnet
@@ -1,0 +1,22 @@
+{
+  driver: {
+    cpp: 'generate_layers',
+    layers: {
+      spill: { parent: 'job', total: 5, starting_number: 1 },
+      // The 'number' child layer is created implicitly by the unfold.
+    },
+  },
+  sources: {
+    vector_source: {
+      cpp: 'vector_source',
+      layer: 'spill',
+    },
+  },
+  modules: {
+    split: {
+      cpp: 'split_square_verify',
+      parent_layer: 'spill',
+      child_layer: 'number',
+    },
+  },
+}

--- a/vector_source.cpp
+++ b/vector_source.cpp
@@ -1,0 +1,19 @@
+#include "phlex/configuration.hpp"
+#include "phlex/model/data_cell_index.hpp"
+#include "phlex/source.hpp"
+
+#include <vector>
+
+using namespace phlex;
+
+PHLEX_REGISTER_PROVIDERS(m, config)
+{
+  auto const layer = config.get<std::string>("layer");
+
+  m.provide("provide_numbers",
+            [](data_cell_index const& id) -> std::vector<int> {
+              auto const n = static_cast<int>(id.number());
+              return {n, n + 1, n + 2};
+            })
+    .output_product("input", "numbers", experimental::identifier{layer});
+}


### PR DESCRIPTION
A pedagogical example demonstrating the unfold higher-order function alongside the existing provide/transform pair. A source emits a small std::vector<int> per spill, an unfold splits the vector into one int per child cell on a 'number' layer, a transform squares each value, and an observe asserts the result is non-negative.

The VectorSplitter class shows the unfold contract: a constructor taking the input product, initial_value(), predicate(state), and unfold(state) -> {next_state, emitted_value}. The framework inspects the constructor signature to determine the expected input products.

CC @knoepfel, implements #15 