### PR TITLE
Updates for Phlex v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains examples of the use of the [Phlex framework](https://gi
 To use the code in this repository, first install it:
 
 ```console
-git clone -b phlex-v0.2 https://github.com/Framework-R-D/phlex-examples.git
+git clone -b phlex-v0.3 https://github.com/Framework-R-D/phlex-examples.git
 ```
 
 Now create a build directory:
@@ -92,4 +92,4 @@ Processed layers:
 > - Cannot be written to output files
 > - Must belong to the `"job"` data layer
 >
-> For Phlex v0.2.0, Python data products cannot be written to output files.
+> For Phlex v0.3.0, Python data products cannot be written to output files.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repository can now be easily built by activating [the environment you create
 
 ```console
 spack env activate my-phlex-environment
-spack load cmake gcc@15  # adjust if you used a different compiler for phlex
+spack load gcc@15 cmake  # adjust if you used a different compiler for phlex
 cmake ../phlex-examples
 make -j 12  # choose a suitable number of jobs for your machine
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Docs**
  - Updated README setup instructions to reference the `phlex-v0.3` branch in the clone command.
  - Adjusted the `spack load` example for the Phlex environment to show `gcc@15 cmake`.
  - Revised the NOTE about Python data products to refer to Phlex v0.3.0 instead of v0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->